### PR TITLE
fix top Navigation

### DIFF
--- a/src/Themes/Nord.php
+++ b/src/Themes/Nord.php
@@ -35,6 +35,7 @@ class Nord implements CanModifyPanelConfig, Theme
     {
         return $panel
             ->topNavigation()
+            ->sidebarCollapsibleOnDesktop(false)
             ->renderHook('panels::page.start', fn () => view('themes::filament.hooks.tenant-menu'));
     }
 }


### PR DESCRIPTION
When using `topNavigation` the `sidebarCollapsibleOnDesktop` has to be false if it is already enabled in the panel

Before:
<img width="1651" alt="Screenshot 2023-09-04 at 8 49 53 PM" src="https://github.com/Hasnayeen/themes/assets/1952412/7de1e138-d5a4-4b39-9725-8469caf1e993">


After:
<img width="1649" alt="Screenshot 2023-09-04 at 8 50 07 PM" src="https://github.com/Hasnayeen/themes/assets/1952412/e50eb66b-0e2e-49ca-b113-b57a36d3c126">

and thank you for this amazing plugin :)
