### PR TITLE
[proposal] check if the plugin enabled for the current panel

### DIFF
--- a/src/Http/Middleware/SetTheme.php
+++ b/src/Http/Middleware/SetTheme.php
@@ -24,6 +24,11 @@ class SetTheme
     {
         $themes = app(Themes::class);
         $panel = Filament::getCurrentPanel();
+
+        if(! $panel->hasPlugin('themes')){
+            return $next($request);
+        }
+
         $panel->userMenuItems(
             ThemesPlugin::canView() ?
             [


### PR DESCRIPTION
If I conventionally disabled the plugin without removing the Middleware, it will throw the exception

```
Plugin [themes] is not registered for panel [admin].
```

This will check if the plugin is enabled in the current panel before initializing the middleware