### PR TITLE
Fix duplication for Octane

### DIFF
--- a/src/Http/Middleware/SetTheme.php
+++ b/src/Http/Middleware/SetTheme.php
@@ -35,12 +35,13 @@ class SetTheme
 
         $panel->userMenuItems(
             ThemesPlugin::canView() ?
-            [
-                MenuItem::make('Themes')
-                    ->label(__('themes::themes.themes'))
-                    ->icon(config('themes.icon'))
-                    ->url(ThemesPage::getUrl()),
-            ] : []
+                [
+                    __('themes::themes.themes') =>
+                    MenuItem::make('Themes')
+                        ->label(__('themes::themes.themes'))
+                        ->icon(config('themes.icon'))
+                        ->url(ThemesPage::getUrl()),
+                ] : []
         );
 
         FilamentColor::register($themes->getCurrentThemeColor());

--- a/src/Http/Middleware/SetTheme.php
+++ b/src/Http/Middleware/SetTheme.php
@@ -33,16 +33,24 @@ class SetTheme
             return $next($request);
         }
 
-        $panel->userMenuItems(
-            ThemesPlugin::canView() ?
-                [
-                    __('themes::themes.themes') =>
-                    MenuItem::make('Themes')
-                        ->label(__('themes::themes.themes'))
-                        ->icon(config('themes.icon'))
-                        ->url(ThemesPage::getUrl()),
-                ] : []
-        );
+        /**
+         * Important for Laravel Octane!
+         * 
+         * Check if item already exists before adding it
+         * to the menu items.
+         */
+        if(!isset($panel->getUserMenuItems()[__('themes::themes.themes')])){
+            $panel->userMenuItems(
+                ThemesPlugin::canView() ?
+                    [
+                        __('themes::themes.themes') =>
+                        MenuItem::make('Themes')
+                            ->label(__('themes::themes.themes'))
+                            ->icon(config('themes.icon'))
+                            ->url(ThemesPage::getUrl()),
+                    ] : []
+            );
+        }
 
         FilamentColor::register($themes->getCurrentThemeColor());
 


### PR DESCRIPTION
Fixes Octane duplication issue
#47 

### Explanation

Laravel Octane keeps the application instance alive across requests, which can lead to issues where stateful operations (like adding menu items) are repeated unintentionally. However, the way PHP arrays handle keys ensures that you can't accidentally add two items with the same key to an associative array.

This solution checks if the **themes** menu item is already in the user menu items. If its not (then its not set). we add the themes menu item, otherwise we skip it! 