### PR TITLE
Only set Dark Mode if Dark Mode hasn't already been forced

### DIFF
--- a/src/Http/Middleware/SetTheme.php
+++ b/src/Http/Middleware/SetTheme.php
@@ -63,7 +63,9 @@ class SetTheme
             },
         ], 'hasnayeen/themes');
 
-        $panel->darkMode(! $currentTheme instanceof HasOnlyLightMode, $currentTheme instanceof HasOnlyDarkMode);
+        if (!$panel->hasDarkModeForced()) {
+            $panel->darkMode(! $currentTheme instanceof HasOnlyLightMode, $currentTheme instanceof HasOnlyDarkMode);
+        }
 
         if ($currentTheme instanceof CanModifyPanelConfig) {
             $currentTheme->modifyPanelConfig($panel);


### PR DESCRIPTION
Adding this change allows the user to force dark mode for any of the custom themes, hiding the dark mode switcher on the user menu