### PR TITLE
Fix user menu label without translate efects

### DIFF
--- a/src/Http/Middleware/SetTheme.php
+++ b/src/Http/Middleware/SetTheme.php
@@ -44,7 +44,7 @@ class SetTheme
                 ThemesPlugin::canView() ?
                     [
                         __('themes::themes.themes') => MenuItem::make('Themes')
-                            ->label(__('themes::themes.themes'))
+                            ->label(fn() => __('themes::themes.themes'))
                             ->icon(config('themes.icon'))
                             ->url(ThemesPage::getUrl()),
                     ] : []


### PR DESCRIPTION
Now we can see user menu label works with translations. I just add the` fn() `